### PR TITLE
Add missing headers

### DIFF
--- a/test/testdecoder.cpp
+++ b/test/testdecoder.cpp
@@ -14,6 +14,7 @@
 #include "libime/jyutping/jyutpingdictionary.h"
 #include "libime/jyutping/jyutpingencoder.h"
 #include "testdir.h"
+#include <limits>
 #include <fcitx-utils/log.h>
 
 using namespace libime;


### PR DESCRIPTION
Similar to https://github.com/fcitx/fcitx5/pull/166 , `limits` must be explicitly included when building with GCC 11 prerelease.